### PR TITLE
fix: adjust share button layout for mobile

### DIFF
--- a/app/views/sheets/shares/_recipient_form.html.erb
+++ b/app/views/sheets/shares/_recipient_form.html.erb
@@ -1,8 +1,8 @@
 <div class="col-md-6 mb-3">
   <%= form_with url: sheets_shares_path(handle: recipient.handle), data: { controller: "redirect", redirect_url_value: sheets_shares_path(filter: "sent"), redirect_refresh_value: true } do |form| %>
     <div class="p-3 bg-body-tertiary shadow-sm rounded border-success border-start border-4">
-      <div class="d-flex align-items-center justify-content-between gap-2">
-        <div class="d-flex align-items-center gap-3 min-w-0">
+      <div class="d-flex align-items-center justify-content-between gap-2 overflow-hidden">
+        <div class="d-flex align-items-center gap-3 min-w-0 flex-grow-1">
           <% if recipient.avatar.attached? %>
             <%= image_tag recipient.avatar, class: "rounded-circle border-success-subtle border-3 object-fit-cover", width: 56, height: 56, alt: "" %>
           <% else %>
@@ -12,14 +12,13 @@
             </span>
           <% end %>
 
-          <div class="min-w-0">
+          <div class="min-w-0 flex-grow-1">
             <h6 class="fw-semibold mb-1 text-truncate"><%= recipient.name %></h6>
             <p class="text-muted small mb-0 text-truncate">@<%= recipient.handle %></p>
           </div>
-        </div>
 
-        <a class="btn btn-sm btn-outline-success" data-bs-toggle="collapse" href="#<%= recipient.handle %>" role="button" aria-expanded="false" aria-controls="<%= recipient.handle %>" title="<%= t('sheets.shares.new.share') %>">
-          <i class="bi bi-send"></i> <%= t('sheets.shares.new.share') %>
+        <a class="btn btn-sm btn-outline-success ms-2 flex-shrink-0" data-bs-toggle="collapse" href="#<%= recipient.handle %>" role="button" aria-expanded="false" aria-controls="<%= recipient.handle %>" title="<%= t('sheets.shares.new.share') %>">
+          <i class="bi bi-send"></i> <span class="d-none d-sm-inline"><%= t('sheets.shares.new.share') %></span>
         </a>
       </div>
 


### PR DESCRIPTION
This PR fixes an issue where the "Share" button was being cut off or hidden on mobile devices.

Changes made:
- Added `overflow-hidden` to the main container.
- Applied `flex-shrink-0` to the share button to prevent it from being squashed.
- Added `d-none d-sm-inline` to the button text, so it only shows the icon on very small screens to save space.

This ensures the layout remains consistent across different screen sizes.