### PR TITLE
improve: form UX — password visibility, placeholders e layout mobile

### DIFF
--- a/app/javascript/controllers/password_visibility_controller.js
+++ b/app/javascript/controllers/password_visibility_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "icon"]
+
+  toggle() {
+    const isPassword = this.inputTarget.type === "password"
+
+    this.#setTargetType(isPassword)
+    this.#toggleIcon(isPassword)
+  }
+
+  #toggleIcon(isPassword) {
+    this.iconTarget.classList.toggle("bi-eye", !isPassword)
+    this.iconTarget.classList.toggle("bi-eye-slash", isPassword)
+  }
+
+  #setTargetType(isPassword) {
+    this.inputTarget.type = isPassword ? "text" : "password"
+  }
+}

--- a/app/models/sheet.rb
+++ b/app/models/sheet.rb
@@ -13,6 +13,7 @@ class Sheet < ApplicationRecord
   has_many :sheet_completions_today, -> { today }, class_name: "SheetCompletion"
 
   validates :sheet_type, inclusion: { in: %w[ workout diet ] }
+  validates :name, presence: true
 
   enum :sheet_type, { workout: "workout", diet: "diet" }
 

--- a/app/views/diets/_form.html.erb
+++ b/app/views/diets/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class='mb-3'>
     <%= form.label :meal, t('.label.meal'), style: "display: block", class: 'form-label' %>
-    <%= form.text_field :meal, class: 'form-control' %>
+    <%= form.text_field :meal, class: 'form-control', placeholder: t('.placeholder.meal') %>
   </div>
 
   <div class='mb-3'>
@@ -23,17 +23,17 @@
 
   <div class='mb-3'>
     <%= form.label :protein_g, t('.label.proteins'), style: "display: block", class: 'form-label' %>
-    <%= form.number_field :protein_g, step: 'any', class: 'form-control' %>
+    <%= form.number_field :protein_g, step: 'any', class: 'form-control', placeholder: t('.placeholder.protein_g') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :carbohydrate_g, t('.label.carbohydrates'), style: "display: block", class: 'form-label' %>
-    <%= form.number_field :carbohydrate_g, step: 'any', class: 'form-control' %>
+    <%= form.number_field :carbohydrate_g, step: 'any', class: 'form-control', placeholder: t('.placeholder.carbohydrate_g') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :fat_g, t('.label.fat'), style: "display: block", class: 'form-label' %>
-    <%= form.number_field :fat_g, step: 'any', class: 'form-control' %>
+    <%= form.number_field :fat_g, step: 'any', class: 'form-control', placeholder: t('.placeholder.fat_g') %>
   </div>
 
   <div>

--- a/app/views/identity/emails/edit.html.erb
+++ b/app/views/identity/emails/edit.html.erb
@@ -41,7 +41,7 @@
     <%= form.label :password_challenge, t('.label.password_challenge'), style: "display: block", class: 'form-label' %>
     <div class="position-relative" data-controller="password-visibility">
       <%= form.password_field :password_challenge, required: true, autocomplete: "current-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
         <i class="bi bi-eye" data-password-visibility-target="icon"></i>
       </button>
     </div>

--- a/app/views/identity/emails/edit.html.erb
+++ b/app/views/identity/emails/edit.html.erb
@@ -34,12 +34,17 @@
 
   <div class='mb-3'>
     <%= form.label :email, t('.label.email'), style: "display: block", class: 'form-label' %>
-    <%= form.email_field :email, required: true, autofocus: true, class: 'form-control' %>
+    <%= form.email_field :email, required: true, autofocus: true, class: 'form-control', placeholder: t('.placeholder.email') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :password_challenge, t('.label.password_challenge'), style: "display: block", class: 'form-label' %>
-    <%= form.password_field :password_challenge, required: true, autocomplete: "current-password", class: 'form-control' %>
+    <div class="position-relative" data-controller="password-visibility">
+      <%= form.password_field :password_challenge, required: true, autocomplete: "current-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+        <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+      </button>
+    </div>
   </div>
 
   <div class='mb-3'>

--- a/app/views/identity/password_resets/edit.html.erb
+++ b/app/views/identity/password_resets/edit.html.erb
@@ -23,13 +23,23 @@
 
   <div class='mb-3'>
     <%= form.label :password, t('.label.password'), style: "display: block", class: 'form-label' %>
-    <%= form.password_field :password, required: true, autofocus: true, autocomplete: "new-password", class: 'form-control' %>
+    <div class="position-relative" data-controller="password-visibility">
+      <%= form.password_field :password, required: true, autofocus: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+        <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+      </button>
+    </div>
     <%= content_tag :small, t('minimum_characters'), class: "text-muted" %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :password_confirmation, t('.label.password_confirmation'), style: "display: block", class: 'form-label' %>
-    <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control' %>
+    <div class="position-relative" data-controller="password-visibility">
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+        <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+      </button>
+    </div>
   </div>
 
   <div>

--- a/app/views/identity/password_resets/edit.html.erb
+++ b/app/views/identity/password_resets/edit.html.erb
@@ -25,7 +25,7 @@
     <%= form.label :password, t('.label.password'), style: "display: block", class: 'form-label' %>
     <div class="position-relative" data-controller="password-visibility">
       <%= form.password_field :password, required: true, autofocus: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
         <i class="bi bi-eye" data-password-visibility-target="icon"></i>
       </button>
     </div>
@@ -36,7 +36,7 @@
     <%= form.label :password_confirmation, t('.label.password_confirmation'), style: "display: block", class: 'form-label' %>
     <div class="position-relative" data-controller="password-visibility">
       <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
         <i class="bi bi-eye" data-password-visibility-target="icon"></i>
       </button>
     </div>

--- a/app/views/identity/password_resets/new.html.erb
+++ b/app/views/identity/password_resets/new.html.erb
@@ -9,7 +9,7 @@
 <%= form_with(url: identity_password_reset_path, data: { controller: "bridge--form", action: "turbo:submit-start->bridge--form#submitStart turbo:submit-end->bridge--form#submitEnd" }) do |form| %>
   <div class='mb-3'>
     <%= form.label :email, style: "display: block", class: 'form-label' %>
-    <%= form.email_field :email, required: true, autofocus: true, class: 'form-control' %>
+    <%= form.email_field :email, required: true, autofocus: true, class: 'form-control', placeholder: t('.placeholder.email') %>
   </div>
 
   <div>

--- a/app/views/identity/profiles/edit.html.erb
+++ b/app/views/identity/profiles/edit.html.erb
@@ -8,9 +8,10 @@
 
 <%= form_with(model: @user, url: identity_profile_path) do |form| %>
   <% if @user.errors.any? %>
-    <div class="alert alert-danger">
-      <strong><%= pluralize(@user.errors.count, t('error')) %> <%= t('.error_message_form') %></strong>
-      <ul class="mb-0 mt-1">
+    <div style="color: red">
+      <h2><%= pluralize(@user.errors.count, t('error')) %> <%= t('.error_message_form') %></h2>
+
+      <ul>
         <% @user.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -20,12 +21,12 @@
 
   <div class='mb-3'>
     <%= form.label :name, t('.name'), style: "display: block", class: 'form-label' %>
-    <%= form.text_field :name, required: true, class: 'form-control' %>
+    <%= form.text_field :name, required: true, class: 'form-control', placeholder: t('.placeholder.name') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :handle, t('.handle'), style: "display: block", class: 'form-label' %>
-    <%= form.text_field :handle, required: true, class: 'form-control' %>
+    <%= form.text_field :handle, required: true, class: 'form-control', placeholder: t('.placeholder.handle') %>
     <span class='form-text'><%= t('.handle_description') %></span>
   </div>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -21,18 +21,33 @@
 
   <div class='mb-3'>
     <%= form.label :password_challenge, t('.label.password_challenge'), style: "display: block", class: 'form-label' %>
-    <%= form.password_field :password_challenge, required: true, autofocus: true, autocomplete: "current-password", class: 'form-control' %>
+    <div class="position-relative" data-controller="password-visibility">
+      <%= form.password_field :password_challenge, required: true, autofocus: true, autocomplete: "current-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+        <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+      </button>
+    </div>
   </div>
 
   <div class='mb-3'>
     <%= form.label :password, t('.label.password'), style: "display: block", class: 'form-label' %>
-    <%= form.password_field :password, required: true, autocomplete: "new-password", class: 'form-control' %>
+    <div class="position-relative" data-controller="password-visibility">
+      <%= form.password_field :password, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+        <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+      </button>
+    </div>
     <%= content_tag :small, t('minimum_characters'), class: "text-muted" %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :password_confirmation, t('.label.password_confirmation'), style: "display: block", class: 'form-label' %>
-    <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control' %>
+    <div class="position-relative" data-controller="password-visibility">
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+        <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+      </button>
+    </div>
   </div>
 
   <div class='mb-3'>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -23,7 +23,7 @@
     <%= form.label :password_challenge, t('.label.password_challenge'), style: "display: block", class: 'form-label' %>
     <div class="position-relative" data-controller="password-visibility">
       <%= form.password_field :password_challenge, required: true, autofocus: true, autocomplete: "current-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
         <i class="bi bi-eye" data-password-visibility-target="icon"></i>
       </button>
     </div>
@@ -33,7 +33,7 @@
     <%= form.label :password, t('.label.password'), style: "display: block", class: 'form-label' %>
     <div class="position-relative" data-controller="password-visibility">
       <%= form.password_field :password, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
         <i class="bi bi-eye" data-password-visibility-target="icon"></i>
       </button>
     </div>
@@ -44,7 +44,7 @@
     <%= form.label :password_confirmation, t('.label.password_confirmation'), style: "display: block", class: 'form-label' %>
     <div class="position-relative" data-controller="password-visibility">
       <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+      <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
         <i class="bi bi-eye" data-password-visibility-target="icon"></i>
       </button>
     </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -44,13 +44,23 @@
 
           <div class="mb-3">
             <%= form.label :password, t('.label.password'), class: 'form-label' %>
-            <%= form.password_field :password, required: true, autocomplete: "new-password", class: 'form-control', placeholder: "••••••••" %>
+            <div class="position-relative" data-controller="password-visibility">
+              <%= form.password_field :password, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+              <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+                <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+              </button>
+            </div>
             <small class="text-muted"><%= t('minimum_characters') %></small>
           </div>
 
           <div class="mb-3">
             <%= form.label :password_confirmation, t('.label.password_confirmation'), class: 'form-label' %>
-            <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control', placeholder: "••••••••" %>
+            <div class="position-relative" data-controller="password-visibility">
+              <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+              <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+                <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+              </button>
+            </div>
           </div>
 
           <div class="mt-4">

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -46,7 +46,8 @@
             <%= form.label :password, t('.label.password'), class: 'form-label' %>
             <div class="position-relative" data-controller="password-visibility">
               <%= form.password_field :password, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-              <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+
+              <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
                 <i class="bi bi-eye" data-password-visibility-target="icon"></i>
               </button>
             </div>
@@ -57,7 +58,8 @@
             <%= form.label :password_confirmation, t('.label.password_confirmation'), class: 'form-label' %>
             <div class="position-relative" data-controller="password-visibility">
               <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-              <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+
+              <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
                 <i class="bi bi-eye" data-password-visibility-target="icon"></i>
               </button>
             </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -32,7 +32,12 @@
             <%= link_to t('.link_forgot_password'), new_identity_password_reset_path, class: 'small' %>
           </div>
 
-          <%= form.password_field :password, required: true, class: 'form-control', placeholder: "••••••••" %>
+          <div class="position-relative" data-controller="password-visibility">
+            <%= form.password_field :password, required: true, class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
+            <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+              <i class="bi bi-eye" data-password-visibility-target="icon"></i>
+            </button>
+          </div>
         </div>
 
         <div class="mb-4">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -34,7 +34,7 @@
 
           <div class="position-relative" data-controller="password-visibility">
             <%= form.password_field :password, required: true, class: 'form-control pe-5', placeholder: "••••••••", data: { "password-visibility-target": "input" } %>
-            <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" tabindex="-1">
+            <button class="btn btn-link position-absolute top-50 end-0 translate-middle-y pe-2 text-body-secondary border-0" type="button" data-action="password-visibility#toggle" aria-label="<%= t('toggle_password_visibility') %>">
               <i class="bi bi-eye" data-password-visibility-target="icon"></i>
             </button>
           </div>

--- a/app/views/sheets/_form.html.erb
+++ b/app/views/sheets/_form.html.erb
@@ -13,12 +13,12 @@
 
   <div class='mb-3'>
     <%= form.label :name, t('.label.name'),style: "display: block", class: 'form-label' %>
-    <%= form.text_field :name, class: 'form-control' %>
+    <%= form.text_field :name, class: 'form-control', placeholder: t('.placeholder.name') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :description, t('.label.description'), style: "display: block", class: 'form-label' %>
-    <%= form.text_area :description, class: 'form-control' %>
+    <%= form.text_area :description, class: 'form-control', placeholder: t('.placeholder.description') %>
   </div>
 
   <div class="mb-3">

--- a/app/views/sheets/shares/_recipient_form.html.erb
+++ b/app/views/sheets/shares/_recipient_form.html.erb
@@ -1,8 +1,8 @@
 <div class="col-md-6 mb-3">
   <%= form_with url: sheets_shares_path(handle: recipient.handle), data: { controller: "redirect", redirect_url_value: sheets_shares_path(filter: "sent"), redirect_refresh_value: true } do |form| %>
     <div class="p-3 bg-body-tertiary shadow-sm rounded border-success border-start border-4">
-      <div class="d-flex align-items-center justify-content-between gap-2 overflow-hidden">
-        <div class="d-flex align-items-center gap-3 min-w-0 flex-grow-1">
+      <div class="d-flex align-items-center justify-content-between gap-2">
+        <div class="d-flex align-items-center gap-3 min-w-0" style="max-width: 65%">
           <% if recipient.avatar.attached? %>
             <%= image_tag recipient.avatar, class: "rounded-circle border-success-subtle border-3 object-fit-cover", width: 56, height: 56, alt: "" %>
           <% else %>
@@ -12,12 +12,13 @@
             </span>
           <% end %>
 
-          <div class="min-w-0 flex-grow-1">
+          <div class="flex-grow-1 overflow-hidden">
             <h6 class="fw-semibold mb-1 text-truncate"><%= recipient.name %></h6>
             <p class="text-muted small mb-0 text-truncate">@<%= recipient.handle %></p>
           </div>
+        </div>
 
-        <a class="btn btn-sm btn-outline-success ms-2 flex-shrink-0" data-bs-toggle="collapse" href="#<%= recipient.handle %>" role="button" aria-expanded="false" aria-controls="<%= recipient.handle %>" title="<%= t('sheets.shares.new.share') %>">
+        <a class="btn btn-sm btn-outline-success flex-shrink-0" data-bs-toggle="collapse" href="#<%= recipient.handle %>" role="button" aria-expanded="false" aria-controls="<%= recipient.handle %>" title="<%= t('sheets.shares.new.share') %>">
           <i class="bi bi-send"></i> <span class="d-none d-sm-inline"><%= t('sheets.shares.new.share') %></span>
         </a>
       </div>

--- a/app/views/social/profiles/index.html.erb
+++ b/app/views/social/profiles/index.html.erb
@@ -5,7 +5,7 @@
 <%= form_with url: social_profiles_path, method: :get, data: { controller: "search", turbo_frame: "profiles" } do |form| %>
   <div class="mb-3">
     <%= form.label :query, t('search') %>
-    <%= form.text_field :query, class: 'form-control', data: { action: "search#submit" } %>
+    <%= form.text_field :query, class: 'form-control', placeholder: t('.placeholder.query'), data: { action: "search#submit" } %>
   </div>
 <% end %>
 

--- a/app/views/workouts/_form.html.erb
+++ b/app/views/workouts/_form.html.erb
@@ -14,23 +14,23 @@
 
   <div class='mb-3'>
     <%= form.label :exercise, t('.label.exercise'), style: "display: block", class: 'form-label' %>
-    <%= form.text_field :exercise, class: 'form-control' %>
+    <%= form.text_field :exercise, class: 'form-control', placeholder: t('.placeholder.exercise') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :series, t('.label.series'), style: "display: block", class: 'form-label' %>
-    <%= form.number_field :series, class: 'form-control' %>
+    <%= form.number_field :series, class: 'form-control', placeholder: t('.placeholder.series') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :repetitions, t('.label.repetitions'), style: "display: block", class: 'form-label' %>
-    <%= form.text_field :repetitions,  maxlength: 20, class: 'form-control' %>
+    <%= form.text_field :repetitions, maxlength: 20, class: 'form-control', placeholder: t('.placeholder.repetitions') %>
   </div>
 
   <div class='mb-3'>
     <%= form.label :interval, t('.label.interval'), style: "display: block", class: 'form-label' %>
 
-    <%= form.number_field :interval, class: 'form-control' %>
+    <%= form.number_field :interval, class: 'form-control', placeholder: t('.placeholder.interval') %>
     <small class='text-muted'><%= t('.help.interval') %></small>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,9 @@ en:
         name:               'Name'
         description:        'Description'
         sheet_type:         'Type'
+      placeholder:
+        name:               'e.g. Workout A'
+        description:        'Sheet description...'
     shares:
       index:
         title:    'Shares'
@@ -186,11 +189,16 @@ en:
     form:
       error_message_form:     'prohibited this workout from being saved:'
       label:
-        name:               'Name'
+        exercise:           'Exercise'
         repetitions:        'Repetitions'
         series:             'Series'
         interval:           'Interval'
         charge:             'Charge'
+      placeholder:
+        exercise:           'e.g. Bench press'
+        series:             'e.g. 4'
+        repetitions:        'e.g. 10-12'
+        interval:           'e.g. 60'
       options_charge:
         low:              'low'
         medium:           'medium'
@@ -221,6 +229,11 @@ en:
         carbohydrates:      'Carbohydrates g'
         proteins:           'Proteins g'
         fat:                'Fat g'
+      placeholder:
+        meal:               'e.g. Breakfast'
+        protein_g:          'e.g. 30'
+        carbohydrate_g:     'e.g. 50'
+        fat_g:              'e.g. 10'
 
 
 
@@ -308,6 +321,8 @@ en:
     profiles:
       index:
         title:     "Profiles"
+        placeholder:
+          query:   'Search users...'
       show:
         followers: "%{count} followers"
         followings: "%{count} following"
@@ -388,6 +403,9 @@ en:
         handle:                  'Handle'
         handle_description:      'Handle is used to identify you in the community.'
         error_message_form:      'prohibited this profile from being saved:'
+        placeholder:
+          name:                  'Your name'
+          handle:                'your-handle'
       show:
         title:                   'Profile'
         profile:                 'Profile'
@@ -412,6 +430,8 @@ en:
         label:
           email:                         'New email'
           password_challenge:            "Password challenge"
+        placeholder:
+          email:                         'email@example.com'
 
     password_resets:
       edit:
@@ -427,6 +447,8 @@ en:
       new:
         title:                     'New password'
         send_reset_email:          'Send password reset email'
+        placeholder:
+          email:                   'email@example.com'
 
   #mailers------------------------------
   greeting:                              "Hello"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
   request:
     processing: "Processing"
   minimum_characters: "6 characters minimum."
+  toggle_password_visibility: 'Toggle password visibility'
   cancel:             "Cancel"
   confirm:            "Confirm"
   follow:             "Follow"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -151,6 +151,9 @@ pt:
         name:               'Nome'
         description:        'Descrição'
         sheet_type:         'Tipo'
+      placeholder:
+        name:               'Ex: Treino A'
+        description:        'Descrição da planilha...'
     shares:
       index:
         title:    'Compartilhamentos'
@@ -196,11 +199,16 @@ pt:
     form:
       error_message_form:     'impediram este treino de ser salvo:'
       label:
-        name:               'Nome'
+        exercise:           'Exercício'
         repetitions:        'Repetições'
         series:             'Séries'
         interval:           'Intervalo'
         charge:             'Carga'
+      placeholder:
+        exercise:           'Ex: Supino reto'
+        series:             'Ex: 4'
+        repetitions:        'Ex: 10-12'
+        interval:           'Ex: 60'
       options_charge:
         low:              'leve'
         medium:           'média'
@@ -231,6 +239,11 @@ pt:
         carbohydrates:      'Carboidratos g'
         proteins:           'Proteínas g'
         fat:                'Gorduras g'
+      placeholder:
+        meal:               'Ex: Café da manhã'
+        protein_g:          'Ex: 30'
+        carbohydrate_g:     'Ex: 50'
+        fat_g:              'Ex: 10'
 
 
   #welcome------------------------------------
@@ -294,6 +307,8 @@ pt:
     profiles:
       index:
         title:     "Perfis"
+        placeholder:
+          query:   'Buscar usuários...'
       show:
         followers: "%{count} seguidores"
         followings: "%{count} seguindo"
@@ -392,6 +407,9 @@ pt:
         handle:                  'Handle'
         handle_description:      'Handle é usado para identificar você na comunidade.'
         error_message_form:      'impediram o perfil de ser salvo:'
+        placeholder:
+          name:                  'Seu nome'
+          handle:                'seu-handle'
       show:
         title:                   'Perfil'
         profile:                 'Perfil'
@@ -415,6 +433,8 @@ pt:
         label:
           email:                         'Novo e-mail'
           password_challenge:            "Senha atual"
+        placeholder:
+          email:                         'email@exemplo.com'
 
     password_resets:
       edit:
@@ -429,6 +449,8 @@ pt:
       new:
         title:                     'Nova senha'
         send_reset_email:          'Enviar e-mail de redefinição de senha'
+        placeholder:
+          email:                   'email@exemplo.com'
 
   #mailers------------------------------
   greeting:                              "Olá"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -40,6 +40,7 @@ pt:
   request:
     processing: "Processando"
   minimum_characters: "Mínimo de 6 caracteres."
+  toggle_password_visibility: 'Alternar visibilidade da senha'
   cancel:             "Cancelar"
   confirm:            "Confirmar"
   all:                'Todos'

--- a/test/models/sheet_test.rb
+++ b/test/models/sheet_test.rb
@@ -2,10 +2,15 @@ require "test_helper"
 
 class SheetTest < ActiveSupport::TestCase
   setup do
-    @workout_sheet = sheets(:one)
-    @diet_sheet = sheets(:two)
+    @workout_sheet       = sheets(:one)
+    @diet_sheet          = sheets(:two)
     @empty_workout_sheet = sheets(:empty_workout)
-    @empty_diet_sheet = sheets(:empty_diet)
+    @empty_diet_sheet    = sheets(:empty_diet)
+  end
+
+  test "should be invalid without a name" do
+    sheet = Sheet.new(sheet_type: :workout, user: @workout_sheet.user)
+    assert_not sheet.valid?
   end
 
   test "should destroy workouts when changing sheet_type to diet" do


### PR DESCRIPTION
## Changes

### Password Visibility Toggle

* Added a new `password-visibility` Stimulus controller with a modern overlay icon (`bi-eye` / `bi-eye-slash`) on password inputs (without using `input-group`).
* Applied to all password fields:

  * Sign in
  * Sign up
  * Change password
  * Reset password
  * Change email

### Placeholders

* Added `placeholder` translation keys to both `pt.yml` and `en.yml` for all form sections.
* Covered areas:

  * Sheets
  * Workouts
  * Diets
  * Profile
  * Email
  * Password resets
  * Profile search
* Password fields use `••••••••` directly.

### Mobile Layout — Recipient Card (`shares/_recipient_form`)

* Added `max-width: 65%` to the left section to ensure proper truncation of name and handle.
* Added `overflow-hidden` and `flex-grow-1` to the text container so `text-truncate` works correctly.
* Added `flex-shrink-0` to the action button to prevent overflow outside the card.
* Hidden button text on small screens (`d-none d-sm-inline`), keeping only the icon visible.

### Model

* Added `validates :name, presence: true` to `Sheet`.
