### PR TITLE
Chore/favicon brakeman update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="icon" type="image/svg+xml" href="/logo.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
 

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="60" height="60" rx="12" fill="#00FF87"/>
+<path d="M40.1 28.2998H32.85V13.7998L19.8 31.1998H27.05V45.6998L40.1 28.2998Z" stroke="black" stroke-width="3" stroke-miterlimit="10" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Replaces the default red circle favicon with the app's SVG logo. 
Also bumps Brakeman from 8.0.4 to 8.0.5 to fix the outdated version CI failure.