### PR TITLE
Improve Puma, Solid Queue and Solid Cable performance

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,7 +8,7 @@ default: &default
   connects_to:
     database:
       writing: cable
-  polling_interval: 0.1.seconds
+  polling_interval: 0.5.seconds
   message_retention: 1.day
 
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -39,6 +39,7 @@ env:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
+    WEB_CONCURRENCY: 2
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,6 +27,9 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
+workers ENV.fetch("WEB_CONCURRENCY", 1)
+preload_app!
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -6,7 +6,7 @@ default: &default
     - queues: "*"
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
+      polling_interval: 1
 
 development:
   <<: *default


### PR DESCRIPTION
## Summary

This pull request introduces performance optimizations for the Rails application running with Puma, Solid Queue, and Solid Cable.

## Changes

- Added Puma worker configuration using `WEB_CONCURRENCY`
- Enabled `WEB_CONCURRENCY=2` in the Kamal deployment configuration
- Increased Solid Cable polling interval from `0.1.seconds` to `0.5.seconds`
- Increased Solid Queue polling interval from `0.1` to `1`

## Benefits

- Better CPU utilization on a 2-core VPS
- Higher request concurrency through multiple Puma workers
- Reduced database load caused by frequent polling
- More efficient background job and cable processing